### PR TITLE
Support KRKG generation on ghosts whose inputs end prematurely (instant finish code support)

### DIFF
--- a/payload/game/kart/KartObjectManager.hh
+++ b/payload/game/kart/KartObjectManager.hh
@@ -6,8 +6,8 @@ namespace Kart {
 
 class KartObjectManager {
 public:
-    REPLACE void end(u32 playerIdx);
-    void REPLACED(end)(u32 playerIdx);
+    REPLACE static void end(u32 playerIdx);
+    static void REPLACED(end)(u32 playerIdx);
 
     const KartObject *object(size_t idx) const;
 

--- a/payload/game/system/KPadDirector.cc
+++ b/payload/game/system/KPadDirector.cc
@@ -1,0 +1,9 @@
+#include "KPadDirector.hh"
+
+namespace System {
+
+KPadDirector *KPadDirector::Instance() {
+    return s_instance;
+}
+
+} // namespace System

--- a/payload/game/system/KPadDirector.hh
+++ b/payload/game/system/KPadDirector.hh
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "game/system/KPadGhostController.hh"
+
+class KPadGhostController;
+
+namespace System {
+
+class KPadDirector {
+public:
+    const KPadGhostController &ghostController(u32 idx) {
+        return m_ghostControllers[idx];
+    }
+
+    static KPadDirector *Instance();
+
+private:
+    u8 _0000[0x3e60 - 0x0000];
+    KPadGhostController m_ghostControllers[4];
+    u8 _4100[0x415c - 0x4100];
+
+    static KPadDirector *s_instance;
+};
+
+} // namespace System

--- a/payload/game/system/KPadGhostController.cc
+++ b/payload/game/system/KPadGhostController.cc
@@ -1,0 +1,34 @@
+#include "KPadGhostController.hh"
+
+#include "game/kart/KartObjectManager.hh"
+
+#include "game/system/KPadDirector.hh"
+#include "game/system/RaceManager.hh"
+
+extern "C" {
+#include <revolution.h>
+}
+
+namespace System {
+
+void KPadGhostController::calcInner(RaceInputState *inputState, UIInputState *uiInputState) {
+    REPLACED(calcInner)(inputState, uiInputState);
+
+    if (this != &KPadDirector::Instance()->ghostController(0)) {
+        return;
+    }
+
+    // End KRKG generation if all 3 input streams have reached the end of input
+    // This handles ghosts created with instant finish code
+    if (RaceManager::Instance() && RaceManager::Instance()->isStageReached(2)) {
+        bool endOfInput = buttonsStreams[0]->state == 2;
+        endOfInput = endOfInput && buttonsStreams[1]->state == 2;
+        endOfInput = endOfInput && buttonsStreams[2]->state == 2;
+
+        if (endOfInput) {
+            Kart::KartObjectManager::Instance()->end(0);
+        }
+    }
+}
+
+} // namespace System

--- a/payload/game/system/KPadGhostController.hh
+++ b/payload/game/system/KPadGhostController.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Common.hh>
+
+namespace System {
+
+class RaceInputState {};
+class UIInputState {};
+
+class GhostButtonsStream {
+public:
+    u8 _00[0x14 - 0x00];
+    u32 state;
+};
+static_assert(sizeof(GhostButtonsStream) == 0x18);
+
+class KPadGhostController {
+public:
+    REPLACE void calcInner(RaceInputState *inputState, UIInputState *uiInputState);
+    void REPLACED(calcInner)(RaceInputState *inputState, UIInputState *uiInputState);
+
+private:
+    u8 _00[0x94 - 0x00];
+    GhostButtonsStream *buttonsStreams[3];
+    u8 _a0[0xa8 - 0xa0];
+};
+static_assert(sizeof(KPadGhostController) == 0xa8);
+
+} // namespace System

--- a/symbols.txt
+++ b/symbols.txt
@@ -70,6 +70,8 @@
 0x8038663c FstStringStart
 0x80386640 FstStart
 
+0x80520b9c _ZN6System19KPadGhostController9calcInnerEPNS_14RaceInputStateEPNS_12UIInputStateE
+
 0x8051bc78 _ZN5Scene9GameScene4drawEv
 
 0x8051c120 _ZNK6System12RawGhostFile7isValidEv
@@ -95,6 +97,7 @@
 
 0x8071763c _ZN5Sound12SoundManager4calcEv
 
+0x809bd70c _ZN6System12KPadDirector10s_instanceE
 0x809bd728 _ZN6System10RaceConfig10s_instanceE
 0x809bd730 _ZN6System11RaceManager10s_instanceE
 


### PR DESCRIPTION
Also fixes `KartObjectManager::end` not being labeled `static`